### PR TITLE
fix: now support button goes to mailto

### DIFF
--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -26,6 +26,11 @@ export function SidebarNavigation() {
     toggleSidebar();
   };
 
+  const handleSupportClick = () => {
+    const mailtoLink = `mailto:support@prolog-app.com?subject=Support Request: `;
+    window.location.href = mailtoLink;
+  };
+
   return (
     <div
       className={classNames(
@@ -89,7 +94,7 @@ export function SidebarNavigation() {
               text="Support"
               iconSrc="/icons/support.svg"
               isCollapsed={isSidebarCollapsed}
-              onClick={() => alert("Support")}
+              onClick={handleSupportClick}
             />
             <MenuItemButton
               text="Collapse"


### PR DESCRIPTION
Now it works when I go to the side bar, press support and it goes to mailto

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved the "Support" button in the sidebar navigation to open the user's default email client for direct assistance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->